### PR TITLE
Downgrade Microsoft.CodeAnalysis.CSharp.Workspaces to v3.5

### DIFF
--- a/src/Dena.CodeAnalysis.Testing/Dena.CodeAnalysis.Testing.csproj
+++ b/src/Dena.CodeAnalysis.Testing/Dena.CodeAnalysis.Testing.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.0" />
     <None Include="LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>


### PR DESCRIPTION
The analyzer project used by Unity is limited to Microsoft.CodeAnalysis.CSharp v3.5 in some packages.
Use them at the same time, CS8032 will occur.

<!-- write content here -->

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
