### PR TITLE
Purge MSTest from Dena.CodeAnalysis.Testing

### DIFF
--- a/src/Dena.CodeAnalysis.Testing/AnalyzerRunner.cs
+++ b/src/Dena.CodeAnalysis.Testing/AnalyzerRunner.cs
@@ -17,7 +17,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 {
     /// <summary>
     /// A runner for <see cref="DiagnosticAnalyzer" />.
-    /// The purpose of the runner is providing another helpers instead of <see cref="AnalyzerVerifier{T1, T2, T3}.VerifyAnalyzerAsync" />.
+    /// The purpose of the runner is providing another helpers instead of <c>AnalyzerVerifier{T1, T2, T3}.VerifyAnalyzerAsync</c>.
     /// The AnalyzerVerifier has several problems:
     ///
     ///   1. Using AnalyzerVerifier, it is hard to instantiate analyzer with custom arguments (it will be needed
@@ -106,7 +106,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
 
         /// <summary>
-        /// This value is equivalent to <see cref="Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest{DiagnosticAnalyzer, IVerifier}.CreateCompilationOptions" />
+        /// This value is equivalent to <c>Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest{DiagnosticAnalyzer, IVerifier}.CreateCompilationOptions</c>.
         /// </summary>
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "This is an exposed API.")]
         public static CompilationOptions CompilationOptionsForDynamicClassLibrary() =>

--- a/src/Dena.CodeAnalysis.Testing/Assert.cs
+++ b/src/Dena.CodeAnalysis.Testing/Assert.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Dena.CodeAnalysis.CSharp.Testing
+{
+    /// <summary>
+    /// Framework-independent assertions.
+    /// </summary>
+    public static class Assert
+    {
+        /// <summary>
+        /// Throw an exception.
+        /// </summary>
+        /// <param name="message">The message of the exception.</param>
+        /// <exception cref="AssertFailedException"></exception>
+        public static void Fail(string message)
+        {
+            throw new AssertFailedException(message);
+        }
+    }
+
+
+    /// <summary>
+    /// An exception for assertions.
+    /// </summary>
+    public class AssertFailedException : Exception
+    {
+        public AssertFailedException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/Dena.CodeAnalysis.Testing/Dena.CodeAnalysis.Testing.csproj
+++ b/src/Dena.CodeAnalysis.Testing/Dena.CodeAnalysis.Testing.csproj
@@ -27,8 +27,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.9.20" />
     <None Include="LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 

--- a/src/Dena.CodeAnalysis.Testing/DiagnosticsFormatter.cs
+++ b/src/Dena.CodeAnalysis.Testing/DiagnosticsFormatter.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Testing;
 
 
 
@@ -33,7 +31,9 @@ namespace Dena.CodeAnalysis.CSharp.Testing
         public static string Format(params Diagnostic[] diagnostics) => Format("path/to/file.cs", diagnostics);
 
 
-        /// <inheritdoc cref="Microsoft.CodeAnalysis.Testing.AnalyzerTest{IVerifier}.FormatDiagnostics(ImmutableArray{DiagnosticAnalyzer}, string, Diagnostic[])"/>
+        /// <summary>
+        /// See <c>Microsoft.CodeAnalysis.Testing.AnalyzerTest{IVerifier}.FormatDiagnostics(ImmutableArray{DiagnosticAnalyzer}, string, Diagnostic[])</c>.
+        /// </summary>
         private static string Format(
             string defaultFilePath,
             params Diagnostic[] diagnostics
@@ -49,11 +49,11 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 var line = diagnostic.Severity switch
                 {
                     DiagnosticSeverity.Error =>
-                        $"{nameof(DiagnosticResult)}.{nameof(DiagnosticResult.CompilerError)}(\"{diagnostic.Id}\")",
+                        $"DiagnosticResult.CompilerError(\"{diagnostic.Id}\")",
                     DiagnosticSeverity.Warning =>
-                        $"{nameof(DiagnosticResult)}.{nameof(DiagnosticResult.CompilerWarning)}(\"{diagnostic.Id}\")",
+                        $"DiagnosticResult.CompilerWarning(\"{diagnostic.Id}\")",
                     _ =>
-                        $"new {nameof(DiagnosticResult)}(\"{diagnostic.Id}\", {nameof(DiagnosticSeverity)}.{diagnostic.Severity})"
+                        $"new DiagnosticResult(\"{diagnostic.Id}\", {nameof(DiagnosticSeverity)}.{diagnostic.Severity})"
                 };
 
                 builder.Append(line);
@@ -72,7 +72,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 var arguments = GetArguments(diagnostic);
                 if (arguments.Count > 0)
                 {
-                    builder.Append($".{nameof(DiagnosticResult.WithArguments)}(");
+                    builder.Append(".DiagnosticResult.WithArguments(");
                     builder.Append(string.Join(", ", arguments.Select(a => $"\"{a}\"")));
                     builder.Append(')');
                 }
@@ -98,7 +98,9 @@ namespace Dena.CodeAnalysis.CSharp.Testing
         }
 
 
-        /// <inheritdoc cref="Microsoft.CodeAnalysis.Testing.AnalyzerTest{IVerifier}.GetArguments(Diagnostic)"/>
+        /// <summary>
+        /// See <c>Microsoft.CodeAnalysis.Testing.AnalyzerTest{IVerifier}.GetArguments(Diagnostic)</c>.
+        /// </summary>
         private static IReadOnlyList<object> GetArguments(Diagnostic diagnostic) =>
             (IReadOnlyList<object>) diagnostic.GetType().GetProperty(
                 "Arguments",

--- a/src/Dena.CodeAnalysis.Testing/LocationAssert.cs
+++ b/src/Dena.CodeAnalysis.Testing/LocationAssert.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 
 

--- a/tests/Dena.CodeAnalysis.Testing.Tests/AnalyzerRunnerTests.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/AnalyzerRunnerTests.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-
+using MSTestAssert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 
 namespace Dena.CodeAnalysis.CSharp.Testing
@@ -13,7 +13,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
         {
             var anyAnalyzer = new NullAnalyzer();
 
-            await Assert.ThrowsExceptionAsync<DiagnosticAnalyzerRunner.AtLeastOneCodeMustBeRequired>(
+            await MSTestAssert.ThrowsExceptionAsync<DiagnosticAnalyzerRunner.AtLeastOneCodeMustBeRequired>(
                 async () => { await DiagnosticAnalyzerRunner.Run(anyAnalyzer); }
             );
         }
@@ -28,7 +28,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 ExampleCode.DiagnosticsFreeClassLibrary
             );
 
-            Assert.AreEqual(0, diagnostics.Length, DiagnosticsFormatter.Format(diagnostics));
+            MSTestAssert.AreEqual(0, diagnostics.Length, DiagnosticsFormatter.Format(diagnostics));
         }
 
 
@@ -41,7 +41,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 ExampleCode.ContainingSyntaxError
             );
 
-            Assert.AreNotEqual(0, diagnostics.Length);
+            MSTestAssert.AreNotEqual(0, diagnostics.Length);
         }
 
 
@@ -52,7 +52,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(spyAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.IsTrue(spyAnalyzer.IsInitialized);
+            MSTestAssert.IsTrue(spyAnalyzer.IsInitialized);
         }
     }
 }

--- a/tests/Dena.CodeAnalysis.Testing.Tests/DiagnosticsFormatterTests.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/DiagnosticsFormatterTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MSTestAssert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 
 
@@ -21,7 +22,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 @"// /0/Test0.cs(9,1): error CS0116: A namespace cannot directly contain members such as fields or methods
 DiagnosticResult.CompilerError(""CS0116"").WithSpan(""/0/Test0.cs"", 9, 1, 9, 6),
 ";
-            Assert.AreEqual(expected, actual);
+            MSTestAssert.AreEqual(expected, actual);
         }
     }
 }

--- a/tests/Dena.CodeAnalysis.Testing.Tests/LocationAssertTest.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/LocationAssertTest.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MSTestAssert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 
 
@@ -39,8 +40,8 @@ namespace Dena.CodeAnalysis.CSharp.Testing
             }
             catch (AssertFailedException e)
             {
-                Assert.AreEqual(
-                    @"Assert.Fail failed.   {
+                MSTestAssert.AreEqual(
+                    @"  {
 -     Path = ""/0/Test999.cs""
 +     Path = ""/0/Test0.cs""
 -     // It will be shown by 1-based index like: ""/0/Test999.cs(1000,1000): Lorem Ipsum ..."")
@@ -87,8 +88,8 @@ namespace Dena.CodeAnalysis.CSharp.Testing
             }
             catch (AssertFailedException e)
             {
-                Assert.AreEqual(
-                    @"Assert.Fail failed.   {
+                MSTestAssert.AreEqual(
+                    @"  {
 -     // It will be shown by 1-based index like: ""/path/to/unchecked.cs(1000,1000): Lorem Ipsum ..."")
 -     StartLinePosition = new LinePosition(999, 999)
 +     // It will be shown by 1-based index like: ""/path/to/unchecked.cs(9,1): Lorem Ipsum ..."")

--- a/tests/Dena.CodeAnalysis.Testing.Tests/SpyAnalyzerTests.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/SpyAnalyzerTests.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MSTestAssert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 
 
@@ -90,7 +91,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 builder.AppendLine(nameof(spy.SyntaxTreeActionHistory));
             }
 
-            Assert.IsFalse(failed, builder.ToString());
+            MSTestAssert.IsFalse(failed, builder.ToString());
         }
     }
 }

--- a/tests/Dena.CodeAnalysis.Testing.Tests/StubAnalyzerTests.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/StubAnalyzerTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MSTestAssert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 
 
@@ -21,7 +22,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -38,7 +39,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -55,7 +56,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -72,7 +73,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -89,7 +90,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -106,7 +107,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -123,7 +124,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -140,7 +141,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -157,7 +158,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -174,7 +175,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -191,7 +192,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
 
 
@@ -208,7 +209,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
 
             await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
 
-            Assert.AreNotEqual(0, callCount);
+            MSTestAssert.AreNotEqual(0, callCount);
         }
     }
 }


### PR DESCRIPTION
Purge MSTest from Dena.CodeAnalysis.Testing, to make other frameworks available.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
