### PR TITLE
Feature: Dena.CodeAnalysis.Testing can read metadata.

### DIFF
--- a/src/Dena.CodeAnalysis.Testing/AnalyzerRunner.cs
+++ b/src/Dena.CodeAnalysis.Testing/AnalyzerRunner.cs
@@ -31,7 +31,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
         /// Run the specified <see cref="DiagnosticAnalyzer" />.
         /// </summary>
         /// <param name="analyzer">The <see cref="DiagnosticAnalyzer" /> to run.</param>
-        /// <param name="types"></param>
+        /// <param name="types">The type of metadata you want to add.</param>
         /// <param name="codes">The target code that the <paramref name="analyzer" /> analyze.</param>
         /// <returns>ImmutableArray contains all reported <see cref="Diagnostic" />.</returns>
         /// <throws>Throws <c cref="AtLeastOneCodeMustBeRequired" /> if <paramref name="codes" /> are empty.</throws>

--- a/src/Dena.CodeAnalysis.Testing/ExampleCode.cs
+++ b/src/Dena.CodeAnalysis.Testing/ExampleCode.cs
@@ -22,6 +22,16 @@ internal static class Foo
 }
 ";
 
+        public const string UniTaskImport = @"
+using Cysharp.Threading.Tasks;
+internal static class Foo
+{
+    internal static void Bar()
+    {
+        System.Console.WriteLine(""Hello, World!"");
+    }
+}";
+
         /// <summary>
         /// An example code that contains a syntax error.
         /// </summary>

--- a/tests/Dena.CodeAnalysis.Testing.Tests/AnalyzerRunnerTests.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/AnalyzerRunnerTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MSTestAssert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
@@ -25,12 +26,24 @@ namespace Dena.CodeAnalysis.CSharp.Testing
             var anyAnalyzer = new NullAnalyzer();
             var diagnostics = await DiagnosticAnalyzerRunner.Run(
                 anyAnalyzer,
-                ExampleCode.DiagnosticsFreeClassLibrary
+                codes: ExampleCode.DiagnosticsFreeClassLibrary
             );
 
             MSTestAssert.AreEqual(0, diagnostics.Length, DiagnosticsFormatter.Format(diagnostics));
         }
 
+        [TestMethod]
+        public async Task WhenGivenUniTaskImport_ItShouldReturnNoDiagnostics()
+        {
+            var anyAnalyzer = new NullAnalyzer();
+            var diagnostics = await DiagnosticAnalyzerRunner.Run(
+                anyAnalyzer,
+                new[] { typeof(UniTask) },
+                ExampleCode.UniTaskImport
+            );
+
+            MSTestAssert.AreEqual(1, diagnostics.Length, DiagnosticsFormatter.Format(diagnostics));
+        }
 
         [TestMethod]
         public async Task WhenGivenContainingASyntaxError_ItShouldReturnSeveralDiagnostics()
@@ -38,7 +51,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
             var anyAnalyzer = new NullAnalyzer();
             var diagnostics = await DiagnosticAnalyzerRunner.Run(
                 anyAnalyzer,
-                ExampleCode.ContainingSyntaxError
+                codes: ExampleCode.ContainingSyntaxError
             );
 
             MSTestAssert.AreNotEqual(0, diagnostics.Length);
@@ -50,7 +63,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
         {
             var spyAnalyzer = new SpyAnalyzer();
 
-            await DiagnosticAnalyzerRunner.Run(spyAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(spyAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.IsTrue(spyAnalyzer.IsInitialized);
         }

--- a/tests/Dena.CodeAnalysis.Testing.Tests/Dena.CodeAnalysis.Testing.Tests.csproj
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/Dena.CodeAnalysis.Testing.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="UniTask" Version="2.3.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Dena.CodeAnalysis.Testing.Tests/Dena.CodeAnalysis.Testing.Tests.csproj
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/Dena.CodeAnalysis.Testing.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>

--- a/tests/Dena.CodeAnalysis.Testing.Tests/DiagnosticsFormatterTests.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/DiagnosticsFormatterTests.cs
@@ -3,7 +3,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MSTestAssert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 
-
 namespace Dena.CodeAnalysis.CSharp.Testing
 {
     [TestClass]
@@ -14,7 +13,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
         {
             var diagnostics = await DiagnosticAnalyzerRunner.Run(
                 new NullAnalyzer(),
-                ExampleCode.ContainingSyntaxError
+                codes: ExampleCode.ContainingSyntaxError
             );
 
             var actual = DiagnosticsFormatter.Format(diagnostics);

--- a/tests/Dena.CodeAnalysis.Testing.Tests/LocationFactory.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/LocationFactory.cs
@@ -11,7 +11,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
         {
             var ds = await DiagnosticAnalyzerRunner.Run(
                 new NullAnalyzer(),
-                ExampleCode.ContainingSyntaxError
+                codes: ExampleCode.ContainingSyntaxError
             );
             return ds[0].Location;
         }

--- a/tests/Dena.CodeAnalysis.Testing.Tests/SpyAnalyzerTests.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/SpyAnalyzerTests.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MSTestAssert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 
-
 namespace Dena.CodeAnalysis.CSharp.Testing
 {
     [TestClass]
@@ -17,7 +16,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
             var builder = new StringBuilder();
             var failed = false;
 
-            await DiagnosticAnalyzerRunner.Run(spy, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(spy, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             if (0 == spy.CodeBlockActionHistory.Count)
             {

--- a/tests/Dena.CodeAnalysis.Testing.Tests/StubAnalyzerTests.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/StubAnalyzerTests.cs
@@ -3,7 +3,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MSTestAssert = Microsoft.VisualStudio.TestTools.UnitTesting.Assert;
 
 
-
 namespace Dena.CodeAnalysis.CSharp.Testing
 {
     [TestClass]
@@ -20,7 +19,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -37,7 +36,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -54,7 +53,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -71,7 +70,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -88,7 +87,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -105,7 +104,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -122,7 +121,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -139,7 +138,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -156,7 +155,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -173,7 +172,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -190,7 +189,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }
@@ -207,7 +206,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 }
             );
 
-            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, ExampleCode.DiagnosticsFreeClassLibrary);
+            await DiagnosticAnalyzerRunner.Run(stubAnalyzer, codes: ExampleCode.DiagnosticsFreeClassLibrary);
 
             MSTestAssert.AreNotEqual(0, callCount);
         }


### PR DESCRIPTION
<!-- write content here -->

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).


# motivation

Until now, when including external libraries in code, it was necessary to prepare dummy implementations each time.
This PR will solve those problems.

## before

- fakes

```csharp
using System.Runtime.CompilerServices;

namespace Cysharp.Threading.Tasks
{
    [AsyncMethodBuilder(typeof(CompilerServices.AsyncUniTaskMethodBuilder))]
    public struct UniTask
    {
    }

    [AsyncMethodBuilder(typeof(CompilerServices.AsyncUniTaskMethodBuilder))]
    public struct UniTaskVoid
    {
    }
}

namespace Cysharp.Threading.Tasks.CompilerServices
{
    public struct AsyncUniTaskMethodBuilder
    {
    }
}

namespace NotSystem.Threading.Tasks
{
    [AsyncMethodBuilder(typeof(CompilerServices.AsyncUniTaskMethodBuilder))]
    public struct Task
    {
    }

    public class CompilerServices
    {
        public class AsyncUniTaskMethodBuilder
        {
        }
    }
}

```

- testcode

```csharp
// Copyright (c) 2020-2023 DeNA Co., Ltd.
// This software is released under the MIT License.

using System.IO;
using System.Linq;
using System.Text;
using System.Threading.Tasks;
using Dena.CodeAnalysis.CSharp.Testing;
using NUnit.Framework;

namespace BanAsyncTaskAnalyzer.Test;

/// <summary>
/// This test is an examples of using the Dena.CodeAnalysis.Testing test helper library.
/// <see href="https://github.com/DeNA/Dena.CodeAnalysis.Testing"/>
/// </summary>
[TestFixture]
public class BanAsyncTaskAnalyzerTest
{    [Test]
    public async Task asyncメソッド_戻り値がUniTask_何もレポートされない()
    {
        var analyzer = new BanAsyncTaskAnalyzer();
        var source = ReadCodes("UseUniTaskCase.txt", "Fakes.cs"); //  ←Need Fake
        var diagnostics = await DiagnosticAnalyzerRunner.Run(analyzer, source);

        var actual = diagnostics
            .Where(x => x.Id != "CS1591") // Ignore "Missing XML comment for publicly visible type or member"
            .Where(x => x.Id != "CS8019") // Ignore "Unnecessary using directive"
            .Where(x => x.Id !=
                        "CS1998") // Ignore "This async method lacks 'await' operators and will run synchronously."
            .ToArray();

        DiagnosticsAssert.IsEmpty(actual);
    }
}
```

## after

```csharp
// Copyright (c) 2020-2023 DeNA Co., Ltd.
// This software is released under the MIT License.

using System.IO;
using System.Linq;
using System.Text;
using System.Threading.Tasks;
using Dena.CodeAnalysis.CSharp.Testing;
using Cysharp.Threading.Tasks
using NUnit.Framework;

namespace BanAsyncTaskAnalyzer.Test;

/// <summary>
/// This test is an examples of using the Dena.CodeAnalysis.Testing test helper library.
/// <see href="https://github.com/DeNA/Dena.CodeAnalysis.Testing"/>
/// </summary>
[TestFixture]
public class BanAsyncTaskAnalyzerTest
{    [Test]
    public async Task asyncメソッド_戻り値がUniTask_何もレポートされない()
    {
        var analyzer = new BanAsyncTaskAnalyzer();
        var source = ReadCodes("UseUniTaskCase.txt"); // 
        var diagnostics = await DiagnosticAnalyzerRunner.Run(analyzer, typeof(UniTask) ,source); // ← no need fake

        var actual = diagnostics
            .Where(x => x.Id != "CS1591") // Ignore "Missing XML comment for publicly visible type or member"
            .Where(x => x.Id != "CS8019") // Ignore "Unnecessary using directive"
            .Where(x => x.Id !=
                        "CS1998") // Ignore "This async method lacks 'await' operators and will run synchronously."
            .ToArray();

        DiagnosticsAssert.IsEmpty(actual);
    }
}
```


