### PR TITLE
Specify the pathname of the file to be analyzed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup .NET
         uses: actions/setup-dotnet@main
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
       - name: dotnet test
         run: dotnet test ./Dena.CodeAnalysis.Testing.sln

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       new-version: ${{ steps.diff.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 200
       - name: Get version from csproj
@@ -31,7 +31,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@main
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: dotnet build
         run: dotnet build ./Dena.CodeAnalysis.Testing.sln  --configuration Release

--- a/src/Dena.CodeAnalysis.Testing/TestDataParser.cs
+++ b/src/Dena.CodeAnalysis.Testing/TestDataParser.cs
@@ -25,19 +25,20 @@ namespace Dena.CodeAnalysis.CSharp.Testing
         /// <c>e.g., {|new Stack()|CS1002|; expected|}</c>
         /// </remarks>
         /// <param name="testData">String containing format in source</param>
+        /// <param name="path">Pathname of the source file</param>
         /// <returns>
         /// 1. Source extracted from *testData*
         /// 2. Returns a List of Diagnostic containing Location, DiagnosticMessage, and DDID
         /// </returns>
         public static (string source, List<Diagnostic> expectedDiagnostics) CreateSourceAndExpectedDiagnostic(
-            string testData)
+            string testData, string path = "/0/Test0.cs")
         {
             var diagnostics = new List<Diagnostic>();
 
             foreach (var (target, ddid, msg) in ExtractMaker(testData))
             {
                 var format = "{|" + target + "|" + ddid + "|" + msg + "|}";
-                Location location = CreateLocation(testData, format, target.Length);
+                Location location = CreateLocation(testData, format, target.Length, path);
                 testData = testData.Replace(format, target);
                 var diagnosticDescriptor = new DiagnosticDescriptor(
                     id: ddid,
@@ -68,12 +69,12 @@ namespace Dena.CodeAnalysis.CSharp.Testing
             }
         }
 
-        internal static Location CreateLocation(string sourceBeforeExtractFormat, string format, int targetLength)
+        internal static Location CreateLocation(string sourceBeforeExtractFormat, string format, int targetLength, string path)
         {
             var start = CreateLinePositionStart(sourceBeforeExtractFormat, format);
             var end = new LinePosition(start.Line, start.Character + targetLength);
             Location location = Location.Create(
-                "/0/Test0.cs",
+                path,
                 new TextSpan(
                     sourceBeforeExtractFormat.IndexOf(format, StringComparison.Ordinal),
                     targetLength),

--- a/tests/Dena.CodeAnalysis.Testing.Tests/TestDataParserTest.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/TestDataParserTest.cs
@@ -264,7 +264,7 @@ namespace BanNonGenericCollectionsAnalyzer.Test.TestData.OperationAction
         [Test]
         public void CreateLocation_ReportPointExistsMiddleLine_GetCorrectSourceSpan()
         {
-            var actual = TestDataParser.CreateLocation("aaa\nbbbc\nccc", "bc", 2);
+            var actual = TestDataParser.CreateLocation("aaa\nbbbc\nccc", "bc", 2, "/0/Test0.cs");
             NUnitAssert.Multiple(() =>
             {
                 NUnitAssert.That(actual.SourceSpan.Start, Is.EqualTo(6));
@@ -275,7 +275,7 @@ namespace BanNonGenericCollectionsAnalyzer.Test.TestData.OperationAction
         [Test]
         public void CreateLocation_ReportPointExistsLastLine_GetCorrectSourceSpan()
         {
-            var actual = TestDataParser.CreateLocation("aaa\nbbbc\nccc", "ccc", 3);
+            var actual = TestDataParser.CreateLocation("aaa\nbbbc\nccc", "ccc", 3, "/0/Test0.cs");
             NUnitAssert.Multiple(() =>
             {
                 NUnitAssert.That(actual.SourceSpan.Start, Is.EqualTo(9));


### PR DESCRIPTION
To test the Roslyn analyzer that depends on the pathname of the file to be analyzed, make it possible to specify the path. Previously, the path was fixed to "/0/Test.cs," but it will now be passed as an argument.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
