### PR TITLE
Fix the issue with the file path specification feature

### DIFF
--- a/src/Dena.CodeAnalysis.Testing/AnalyzerRunner.cs
+++ b/src/Dena.CodeAnalysis.Testing/AnalyzerRunner.cs
@@ -46,6 +46,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
                 ParseOptionsForLanguageVersionsDefault(),
                 CompilationOptionsForDynamicClassLibrary(),
                 MetadataReferencesDefault(types),
+                "",
                 codes
             );
 
@@ -56,6 +57,8 @@ namespace Dena.CodeAnalysis.CSharp.Testing
         /// <param name="cancellationToken">The <see cref="CancellationToken" /> that the task will observe.</param>
         /// <param name="parseOptions">The <see cref="ParseOptions" />. </param>
         /// <param name="compilationOptions">The <see cref="CompilationOptions" />. Use <see cref="OutputKind.ConsoleApplication"/> if you want to analyze codes including <c>Main()</c> (default: <see cref="OutputKind.DynamicallyLinkedLibrary" />).</param>
+        /// <param name="metadataReferences">The <see cref="MetadataReference" />s to add to the compilation.</param>
+        /// <param name="filePath">The file path of the source code. This is used to set the <see cref="SyntaxTree.FilePath" /> property.</param>
         /// <param name="codes">The target code that the <paramref name="analyzer" /> analyze. Use <see cref="LanguageVersion" /> if you want to specify C# version (default: <see cref="LanguageVersion.Default" />)."</param>
         /// <returns>ImmutableArray contains all reported <see cref="Diagnostic" />.</returns>
         /// <throws>Throws <c cref="AtLeastOneCodeMustBeRequired" /> if <paramref name="codes" /> are empty.</throws>
@@ -66,6 +69,7 @@ namespace Dena.CodeAnalysis.CSharp.Testing
             ParseOptions parseOptions,
             CompilationOptions compilationOptions,
             IEnumerable<MetadataReference> metadataReferences,
+            string filePath = "",
             params string[] codes
         )
         {
@@ -87,7 +91,8 @@ namespace Dena.CodeAnalysis.CSharp.Testing
             foreach (var code in codes)
             {
                 var documentId = DocumentId.CreateNewId(projectId);
-                solution = solution.AddDocument(documentId, DefaultFilePath, code, filePath: DefaultFilePath);
+                var path = filePath.Length > 0 ? filePath : DefaultFilePath;
+                solution = solution.AddDocument(documentId, path, code, filePath: path);
             }
 
             var noMetadataReferencedProject = solution.Projects.First();

--- a/src/Dena.CodeAnalysis.Testing/Dena.CodeAnalysis.Testing.csproj
+++ b/src/Dena.CodeAnalysis.Testing/Dena.CodeAnalysis.Testing.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PackageId>Dena.CodeAnalysis.Testing</PackageId>
-    <PackageVersion>3.0.5</PackageVersion>
+    <PackageVersion>3.0.6</PackageVersion>
     <Authors>Kazuma Inagaki, Koji Hasegawa, Kuniwak</Authors>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Test helpers for DiagnosticAnalyzers</Description>

--- a/src/Dena.CodeAnalysis.Testing/TestDataParser.cs
+++ b/src/Dena.CodeAnalysis.Testing/TestDataParser.cs
@@ -25,20 +25,19 @@ namespace Dena.CodeAnalysis.CSharp.Testing
         /// <c>e.g., {|new Stack()|CS1002|; expected|}</c>
         /// </remarks>
         /// <param name="testData">String containing format in source</param>
-        /// <param name="path">Pathname of the source file</param>
         /// <returns>
         /// 1. Source extracted from *testData*
         /// 2. Returns a List of Diagnostic containing Location, DiagnosticMessage, and DDID
         /// </returns>
         public static (string source, List<Diagnostic> expectedDiagnostics) CreateSourceAndExpectedDiagnostic(
-            string testData, string path = "/0/Test0.cs")
+            string testData)
         {
             var diagnostics = new List<Diagnostic>();
 
             foreach (var (target, ddid, msg) in ExtractMaker(testData))
             {
                 var format = "{|" + target + "|" + ddid + "|" + msg + "|}";
-                Location location = CreateLocation(testData, format, target.Length, path);
+                Location location = CreateLocation(testData, format, target.Length);
                 testData = testData.Replace(format, target);
                 var diagnosticDescriptor = new DiagnosticDescriptor(
                     id: ddid,
@@ -69,12 +68,12 @@ namespace Dena.CodeAnalysis.CSharp.Testing
             }
         }
 
-        internal static Location CreateLocation(string sourceBeforeExtractFormat, string format, int targetLength, string path)
+        internal static Location CreateLocation(string sourceBeforeExtractFormat, string format, int targetLength)
         {
             var start = CreateLinePositionStart(sourceBeforeExtractFormat, format);
             var end = new LinePosition(start.Line, start.Character + targetLength);
             Location location = Location.Create(
-                path,
+                "/0/Test0.cs",
                 new TextSpan(
                     sourceBeforeExtractFormat.IndexOf(format, StringComparison.Ordinal),
                     targetLength),

--- a/tests/Dena.CodeAnalysis.Testing.Tests/TestDataParserTest.cs
+++ b/tests/Dena.CodeAnalysis.Testing.Tests/TestDataParserTest.cs
@@ -264,7 +264,7 @@ namespace BanNonGenericCollectionsAnalyzer.Test.TestData.OperationAction
         [Test]
         public void CreateLocation_ReportPointExistsMiddleLine_GetCorrectSourceSpan()
         {
-            var actual = TestDataParser.CreateLocation("aaa\nbbbc\nccc", "bc", 2, "/0/Test0.cs");
+            var actual = TestDataParser.CreateLocation("aaa\nbbbc\nccc", "bc", 2);
             NUnitAssert.Multiple(() =>
             {
                 NUnitAssert.That(actual.SourceSpan.Start, Is.EqualTo(6));
@@ -275,7 +275,7 @@ namespace BanNonGenericCollectionsAnalyzer.Test.TestData.OperationAction
         [Test]
         public void CreateLocation_ReportPointExistsLastLine_GetCorrectSourceSpan()
         {
-            var actual = TestDataParser.CreateLocation("aaa\nbbbc\nccc", "ccc", 3, "/0/Test0.cs");
+            var actual = TestDataParser.CreateLocation("aaa\nbbbc\nccc", "ccc", 3);
             NUnitAssert.Multiple(() =>
             {
                 NUnitAssert.That(actual.SourceSpan.Start, Is.EqualTo(9));


### PR DESCRIPTION
To specify the file path for analysis, it was necessary to use `Solution` instead of `Location`.

---

### Contribution License Agreement

- [x] By placing an "x" in the box, I hereby understand, accept and agree to be bound by the terms and conditions of the [Contribution License Agreement](https://dena.github.io/cla/).
